### PR TITLE
set minifyEnabled to false for all flavors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
         release {
-            minifyEnabled true
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
@@ -268,5 +268,3 @@ artifacts {
     archives androidJavadocsJar
     archives androidJar
 }
-
-


### PR DESCRIPTION
This should give us proper crashlogs since the obfuscation will only happen at the last phase of app compilation.

@applicaster/zee5-engineers